### PR TITLE
News History Implemented

### DIFF
--- a/app/src/main/java/com/example/sprint_2_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/MainActivity.kt
@@ -26,6 +26,7 @@ import com.example.sprint_2_kotlin.view.GuideScreen
 import com.example.sprint_2_kotlin.view.NewsFeedScreen
 import com.example.sprint_2_kotlin.view.NewsItemDetailScreen
 import com.example.sprint_2_kotlin.view.ProfileScreen
+import com.example.sprint_2_kotlin.view.ReadHistoryScreen  // ✅ AGREGADO
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.StateFlow
 import androidx.compose.runtime.collectAsState
@@ -44,7 +45,7 @@ class MainActivity : FragmentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            // ✅ DARK MODE STATE - Lee la preferencia guardada
+            // DARK MODE STATE - Lee la preferencia guardada
             val isDarkMode by ThemePreferences.isDarkMode(this).collectAsState(initial = false)
             val coroutineScope = rememberCoroutineScope()
 
@@ -56,7 +57,7 @@ class MainActivity : FragmentActivity() {
 
                     Column(modifier = Modifier.fillMaxSize()) {
 
-                        // ✅ CONNECTIVITY BANNER
+                        //  CONNECTIVITY BANNER
                         ConnectivityBanner(isConnected = isConnected)
 
                         NavHost(
@@ -171,6 +172,24 @@ class MainActivity : FragmentActivity() {
                                     },
                                     onNavigateToGuide = {
                                         navController.navigate(Screen.Guide.route)
+                                    },
+                                    onNavigateToReadHistory = {  //  update!!
+                                        navController.navigate(Screen.ReadHistory.route)
+                                    }
+                                )
+                            }
+
+                            // update!! : Ruta para Read History Screen
+                            composable(route = Screen.ReadHistory.route) {
+                                ReadHistoryScreen(
+                                    isDarkMode = isDarkMode,
+                                    onBackClick = {
+                                        navController.popBackStack()
+                                    },
+                                    onNewsItemClick = { newsItemId ->
+                                        navController.navigate(
+                                            Screen.NewsItemDetail.createRoute(newsItemId)
+                                        )
                                     }
                                 )
                             }

--- a/app/src/main/java/com/example/sprint_2_kotlin/Navigation.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/Navigation.kt
@@ -9,6 +9,8 @@ sealed class Screen(val route: String) {
     }
     object Guide : Screen("guide")
     object Profile : Screen("profile")
+
+    object ReadHistory : Screen("read_history")  // update: Ruta para historial de lectura
 }
 
 

--- a/app/src/main/java/com/example/sprint_2_kotlin/model/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/model/data/AppDatabase.kt
@@ -10,8 +10,12 @@ import androidx.room.RoomDatabase
  * This is the main database configuration with all entities and version
  */
 @Database(
-    entities = [NewsItemEntity::class, PendingComment::class],
-    version = 2,
+    entities = [
+        NewsItemEntity::class,
+        PendingComment::class,
+        ReadHistoryEntity::class  // update: Nueva entidad para historial de lectura
+    ],
+    version = 3,  // cambiao-> Incrementado de 2 a 3
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -21,6 +25,7 @@ abstract class AppDatabase : RoomDatabase() {
      */
     abstract fun newsItemDao(): NewsItemDao
     abstract fun CommentDao(): CommentDao
+    abstract fun readHistoryDao(): ReadHistoryDao  // update: DAO para historial de lectura
 
     companion object {
         // Singleton prevents multiple instances of database opening at the same time

--- a/app/src/main/java/com/example/sprint_2_kotlin/model/data/ReadHistoryDao.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/model/data/ReadHistoryDao.kt
@@ -1,0 +1,87 @@
+package com.example.sprint_2_kotlin.model.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO (Data Access Object) for Read History operations
+ * Provides methods to track and retrieve user's reading history
+ */
+@Dao
+interface ReadHistoryDao {
+
+    /**
+     * Insert a new read history entry
+     * OnConflictStrategy.IGNORE prevents duplicate entries for the same news item
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertReadHistory(readHistory: ReadHistoryEntity)
+
+    /**
+     * Get all read history entries as Flow (reactive updates)
+     * Ordered by most recent first
+     */
+    @Query("SELECT * FROM read_history ORDER BY readTimestamp DESC")
+    fun getAllReadHistory(): Flow<List<ReadHistoryEntity>>
+
+    /**
+     * Get all read history entries as a single list (non-reactive)
+     * Useful for one-time queries
+     */
+    @Query("SELECT * FROM read_history ORDER BY readTimestamp DESC")
+    suspend fun getAllReadHistoryList(): List<ReadHistoryEntity>
+
+    /**
+     * Get the total count of articles read by the user
+     * Used for the "Articles read" counter in ProfileScreen
+     */
+    @Query("SELECT COUNT(*) FROM read_history")
+    suspend fun getReadCount(): Int
+
+    /**
+     * Get the total count of articles read as Flow (reactive)
+     * Updates automatically when new articles are read
+     */
+    @Query("SELECT COUNT(*) FROM read_history")
+    fun getReadCountFlow(): Flow<Int>
+
+    /**
+     * Check if a specific news item has already been read
+     * Returns true if exists, false otherwise
+     * Used to prevent duplicate entries
+     */
+    @Query("SELECT EXISTS(SELECT 1 FROM read_history WHERE newsItemId = :newsItemId LIMIT 1)")
+    suspend fun isNewsItemRead(newsItemId: Int): Boolean
+
+    /**
+     * Get read history filtered by category
+     */
+    @Query("SELECT * FROM read_history WHERE categoryId = :categoryId ORDER BY readTimestamp DESC")
+    fun getReadHistoryByCategory(categoryId: Int): Flow<List<ReadHistoryEntity>>
+
+    /**
+     * Delete a specific history entry
+     */
+    @Query("DELETE FROM read_history WHERE id = :historyId")
+    suspend fun deleteHistoryEntry(historyId: Int)
+
+    /**
+     * Delete all read history (clear history)
+     */
+    @Query("DELETE FROM read_history")
+    suspend fun deleteAllHistory()
+
+    /**
+     * Get the most recent N articles read
+     * Useful for showing "Recently read" section
+     */
+    @Query("SELECT * FROM read_history ORDER BY readTimestamp DESC LIMIT :limit")
+    suspend fun getRecentReadHistory(limit: Int = 10): List<ReadHistoryEntity>
+
+    /**
+     * Delete old history entries (older than specified timestamp)
+     * Useful for implementing automatic cleanup
+     */
+    @Query("DELETE FROM read_history WHERE readTimestamp < :expirationTimestamp")
+    suspend fun deleteOldHistory(expirationTimestamp: Long)
+}

--- a/app/src/main/java/com/example/sprint_2_kotlin/model/data/ReadHistoryEntity.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/model/data/ReadHistoryEntity.kt
@@ -1,0 +1,56 @@
+package com.example.sprint_2_kotlin.model.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Entity for storing read history locally
+ * Tracks which news items a user has read
+ * Only stores the first time a news item is opened
+ */
+@Entity(tableName = "read_history")
+data class ReadHistoryEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val newsItemId: Int,              // ID of the news item (references news_items table)
+    val title: String,                // Title of the news
+    val shortDescription: String,     // Short description
+    val imageUrl: String,             // Image URL for thumbnail
+    val categoryId: Int,              // Category ID
+    val readTimestamp: Long,          // When it was read (milliseconds since epoch)
+    val authorType: String = "",      // Author type (e.g., "Journalist", "Researcher")
+    val authorInstitution: String = "" // Author institution
+)
+
+/**
+ * Extension function to convert ReadHistoryEntity to NewsItem
+ * Useful for navigating to news detail from history
+ */
+fun ReadHistoryEntity.toNewsItem(): NewsItem {
+    return NewsItem(
+        news_item_id = this.newsItemId,
+        title = this.title,
+        short_description = this.shortDescription,
+        image_url = this.imageUrl,
+        category_id = this.categoryId,
+        author_type = this.authorType,
+        author_institution = this.authorInstitution
+    )
+}
+
+/**
+ * Extension function to create ReadHistoryEntity from NewsItem
+ * Used when registering a new read event
+ */
+fun NewsItem.toReadHistoryEntity(): ReadHistoryEntity {
+    return ReadHistoryEntity(
+        newsItemId = this.news_item_id,
+        title = this.title,
+        shortDescription = this.short_description,
+        imageUrl = this.image_url,
+        categoryId = this.category_id,
+        readTimestamp = System.currentTimeMillis(),
+        authorType = this.author_type,
+        authorInstitution = this.author_institution
+    )
+}

--- a/app/src/main/java/com/example/sprint_2_kotlin/view/NewsItemDetailScreen.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/view/NewsItemDetailScreen.kt
@@ -45,7 +45,14 @@ fun NewsItemDetailScreen(
         viewModel.startNetworkObserver(networkMonitor, newsItemId)
     }
 
+    // update : Register read history when news item is loaded
     val currentItem by viewModel.newsItem.collectAsState()
+    LaunchedEffect(currentItem) {
+        currentItem?.let { newsItem ->
+            viewModel.registerReadHistory(newsItem)
+        }
+    }
+
     val ratings by viewModel.ratings.collectAsState()
 
     // Colores dinámicos según el tema

--- a/app/src/main/java/com/example/sprint_2_kotlin/view/ProfileScreen.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/view/ProfileScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.sprint_2_kotlin.viewmodel.ReadHistoryViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -28,10 +31,12 @@ fun ProfileScreen(
     onToggleDarkMode: (Boolean) -> Unit = {},
     onLogout: () -> Unit = {},
     onNavigateToHome: () -> Unit = {},
-    onNavigateToGuide: () -> Unit = {}
+    onNavigateToGuide: () -> Unit = {},
+    onNavigateToReadHistory: () -> Unit = {},  // ✅ AGREGADO: Navegación al historial
+    readHistoryViewModel: ReadHistoryViewModel = viewModel()  // ✅ AGREGADO: ViewModel
 ) {
     var selectedTab by remember { mutableStateOf(0) }
-    val tabs = listOf("Activity", "Achievements", "Settings", "Bookmarks")
+    val tabs = listOf("Activity", "Achievements", "Bookmarks")  // ✅ MODIFICADO: Quitado "Settings"
 
     // Admin panel states
     var showPasswordDialog by remember { mutableStateOf(false) }
@@ -40,6 +45,9 @@ fun ProfileScreen(
 
     // Edit Profile dialog state
     var showEditProfileDialog by remember { mutableStateOf(false) }
+
+    // ✅ AGREGADO: Obtener contador de artículos leídos
+    val readCount by readHistoryViewModel.readCount.collectAsState()
 
     // Colores dinámicos según el tema
     val backgroundColor = if (isDarkMode) Color(0xFF121212) else Color(0xFFF5F5F5)
@@ -138,7 +146,11 @@ fun ProfileScreen(
             }
 
             item {
-                StatisticsGrid(isDarkMode = isDarkMode)
+                StatisticsGrid(
+                    isDarkMode = isDarkMode,
+                    readCount = readCount,  // ✅ AGREGADO: Pasar contador real
+                    onReadHistoryClick = onNavigateToReadHistory  // ✅ AGREGADO: Callback para navegación
+                )
                 Spacer(Modifier.height(16.dp))
             }
 
@@ -464,7 +476,11 @@ fun Badge(
 }
 
 @Composable
-fun StatisticsGrid(isDarkMode: Boolean = false) {
+fun StatisticsGrid(
+    isDarkMode: Boolean = false,
+    readCount: Int = 0,  // ✅ AGREGADO: Parámetro para contador real
+    onReadHistoryClick: () -> Unit = {}  // ✅ AGREGADO: Callback para navegación
+) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -472,11 +488,12 @@ fun StatisticsGrid(isDarkMode: Boolean = false) {
         ) {
             StatCard(
                 icon = Icons.Default.Visibility,
-                value = "342",
+                value = "$readCount",  // ✅ MODIFICADO: Usar contador real
                 label = "Articles read",
                 iconColor = Color(0xFF2196F3),
                 isDarkMode = isDarkMode,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                onClick = onReadHistoryClick  // ✅ AGREGADO: Hacer clickeable
             )
             StatCard(
                 icon = Icons.Default.Flag,
@@ -511,6 +528,7 @@ fun StatisticsGrid(isDarkMode: Boolean = false) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StatCard(
     icon: ImageVector,
@@ -518,7 +536,8 @@ fun StatCard(
     label: String,
     iconColor: Color,
     isDarkMode: Boolean = false,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null  // ✅ AGREGADO: Parámetro opcional para click
 ) {
     val surfaceColor = if (isDarkMode) Color(0xFF1E1E1E) else Color.White
     val textColor = if (isDarkMode) Color(0xFFE1E1E1) else Color(0xFF1A1A1A)
@@ -528,7 +547,8 @@ fun StatCard(
         modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = surfaceColor),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        onClick = { onClick?.invoke() }  // ✅ AGREGADO: Hacer clickeable si hay onClick
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/example/sprint_2_kotlin/view/ReadHistoryScreen.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/view/ReadHistoryScreen.kt
@@ -1,0 +1,378 @@
+package com.example.sprint_2_kotlin.view
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
+import com.example.sprint_2_kotlin.model.data.ReadHistoryEntity
+import com.example.sprint_2_kotlin.viewmodel.ReadHistoryViewModel
+import com.example.sprint_2_kotlin.viewmodel.NewsFeedViewModel  // update
+import com.example.sprint_2_kotlin.viewmodel.RatingDistributionViewModel  // update
+import java.text.SimpleDateFormat
+import java.util.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadHistoryScreen(
+    isDarkMode: Boolean = false,
+    onBackClick: () -> Unit = {},
+    onNewsItemClick: (Int) -> Unit = {},
+    viewModel: ReadHistoryViewModel = viewModel(),
+    newsFeedViewModel: NewsFeedViewModel = viewModel(),  // update: Para acceder a getCategoryLabel
+    ratingViewModel: RatingDistributionViewModel = viewModel()  // update: Para acceder a getCategoryColor
+) {
+    val readHistory by viewModel.readHistory.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val readCount by viewModel.readCount.collectAsState()
+
+    // Colores dinámicos según el tema
+    val backgroundColor = if (isDarkMode) Color(0xFF121212) else Color(0xFFF5F5F5)
+    val surfaceColor = if (isDarkMode) Color(0xFF1E1E1E) else Color.White
+    val textColor = if (isDarkMode) Color(0xFFE1E1E1) else Color(0xFF1A1A1A)
+    val secondaryTextColor = if (isDarkMode) Color(0xFFB0B0B0) else Color(0xFF666666)
+
+    // Dialog state for confirming clear all
+    var showClearDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            "Read History",
+                            color = textColor,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            "$readCount articles read",
+                            color = secondaryTextColor,
+                            fontSize = 12.sp
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = textColor
+                        )
+                    }
+                },
+                actions = {
+                    if (readHistory.isNotEmpty()) {
+                        IconButton(onClick = { showClearDialog = true }) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Clear History",
+                                tint = Color(0xFFE53935)
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = surfaceColor
+                )
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(backgroundColor)
+                .padding(paddingValues)
+        ) {
+            when {
+                isLoading -> {
+                    // Loading state
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.Center),
+                        color = if (isDarkMode) Color(0xFF9C27B0) else Color(0xFF1976D2)
+                    )
+                }
+                readHistory.isEmpty() -> {
+                    // Empty state
+                    EmptyHistoryState(
+                        isDarkMode = isDarkMode,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                else -> {
+                    // History list
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(
+                            items = readHistory,
+                            key = { it.id }
+                        ) { historyItem ->
+                            ReadHistoryCard(
+                                historyItem = historyItem,
+                                isDarkMode = isDarkMode,
+                                categoryLabel = newsFeedViewModel.getCategoryLabel(historyItem.categoryId),  // modified
+                                categoryColor = ratingViewModel.getCategoryColor(historyItem.categoryId),  // update
+                                onClick = { onNewsItemClick(historyItem.newsItemId) }
+                            )
+                        }
+
+                        // Bottom spacer
+                        item {
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Clear All History Dialog
+    if (showClearDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearDialog = false },
+            containerColor = surfaceColor,
+            icon = {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete",
+                    tint = Color(0xFFE53935),
+                    modifier = Modifier.size(32.dp)
+                )
+            },
+            title = {
+                Text(
+                    text = "Clear History?",
+                    fontWeight = FontWeight.Bold,
+                    color = textColor
+                )
+            },
+            text = {
+                Text(
+                    text = "This will permanently delete all your read history. This action cannot be undone.",
+                    color = secondaryTextColor
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        viewModel.clearAllHistory()
+                        showClearDialog = false
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFFE53935)
+                    )
+                ) {
+                    Text("Clear All", color = Color.White)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showClearDialog = false }
+                ) {
+                    Text("Cancel", color = textColor)
+                }
+            }
+        )
+    }
+}
+
+@Composable
+fun ReadHistoryCard(
+    historyItem: ReadHistoryEntity,
+    isDarkMode: Boolean = false,
+    categoryLabel: String = "General",  //update: Parámetro para nombre de categoría
+    categoryColor: Color = Color.Gray,  // update: Parámetro para color de categoría
+    onClick: () -> Unit = {}
+) {
+    val surfaceColor = if (isDarkMode) Color(0xFF1E1E1E) else Color.White
+    val textColor = if (isDarkMode) Color(0xFFE1E1E1) else Color(0xFF1A1A1A)
+    val secondaryTextColor = if (isDarkMode) Color(0xFFB0B0B0) else Color(0xFF666666)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = surfaceColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp)
+        ) {
+            // Image thumbnail
+            if (historyItem.imageUrl.isNotEmpty()) {
+                Image(
+                    painter = rememberAsyncImagePainter(historyItem.imageUrl),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(80.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(Modifier.width(12.dp))
+            }
+
+            // Content
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                // Title
+                Text(
+                    text = historyItem.title,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = textColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(Modifier.height(6.dp))
+
+                // Short description
+                if (historyItem.shortDescription.isNotEmpty()) {
+                    Text(
+                        text = historyItem.shortDescription,
+                        fontSize = 13.sp,
+                        color = secondaryTextColor,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(Modifier.height(6.dp))
+                }
+
+                // Meta info (category, author, time)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Category badge - update: Ahora usa el nombre y color real
+                    Surface(
+                        shape = RoundedCornerShape(4.dp),
+                        color = categoryColor.copy(alpha = 0.15f)  //Color con transparencia
+                    ) {
+                        Text(
+                            text = categoryLabel,  // Update: Muestra el nombre en lugar del ID
+                            fontSize = 11.sp,
+                            color = categoryColor,  //Update: Usa el color de la categoría
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+
+                    // Time ago
+                    Text(
+                        text = formatTimeAgo(historyItem.readTimestamp),
+                        fontSize = 11.sp,
+                        color = secondaryTextColor
+                    )
+                }
+
+                // Author info
+                if (historyItem.authorType.isNotEmpty()) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "By ${historyItem.authorType}${
+                            if (historyItem.authorInstitution.isNotEmpty())
+                                " at ${historyItem.authorInstitution}"
+                            else ""
+                        }",
+                        fontSize = 11.sp,
+                        color = secondaryTextColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EmptyHistoryState(
+    isDarkMode: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    val textColor = if (isDarkMode) Color(0xFFE1E1E1) else Color(0xFF1A1A1A)
+    val secondaryTextColor = if (isDarkMode) Color(0xFFB0B0B0) else Color(0xFF666666)
+
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.History,
+            contentDescription = "No history",
+            modifier = Modifier.size(80.dp),
+            tint = secondaryTextColor.copy(alpha = 0.5f)
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = "No Reading History",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = textColor
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "Articles you read will appear here",
+            fontSize = 14.sp,
+            color = secondaryTextColor,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+    }
+}
+
+/**
+ * Format timestamp to relative time (e.g., "2 hours ago", "Yesterday")
+ */
+private fun formatTimeAgo(timestamp: Long): String {
+    val now = System.currentTimeMillis()
+    val diff = now - timestamp
+
+    val seconds = diff / 1000
+    val minutes = seconds / 60
+    val hours = minutes / 60
+    val days = hours / 24
+
+    return when {
+        seconds < 60 -> "Just now"
+        minutes < 60 -> "$minutes min ago"
+        hours < 24 -> "$hours hour${if (hours > 1) "s" else ""} ago"
+        days == 1L -> "Yesterday"
+        days < 7 -> "$days days ago"
+        else -> {
+            // Format as date for older entries
+            val sdf = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+            sdf.format(Date(timestamp))
+        }
+    }
+}

--- a/app/src/main/java/com/example/sprint_2_kotlin/viewmodel/NewsItemDetailViewModel.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/viewmodel/NewsItemDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.example.sprint_2_kotlin.model.data.AppDatabase
 import com.example.sprint_2_kotlin.model.data.NewsItem
 import com.example.sprint_2_kotlin.model.data.RatingItem
 import com.example.sprint_2_kotlin.model.data.UserProfile
+import com.example.sprint_2_kotlin.model.data.toReadHistoryEntity
 import com.example.sprint_2_kotlin.model.network.NetworkStatusTracker
 import com.example.sprint_2_kotlin.model.repository.Repository
 import kotlinx.coroutines.Dispatchers
@@ -27,14 +28,15 @@ import utils.NetworkMonitor
  * CHANGE: Now extends AndroidViewModel to pass context to Repository
  */
 class NewsItemDetailViewModel(
-    application: Application // CAMBIO: ahora recibe Application
-) : AndroidViewModel(application) { //  CAMBIO: extiende AndroidViewModel
+    application: Application // update: ahora recibe Application
+) : AndroidViewModel(application) { //  update: extiende AndroidViewModel
 
     private val _isConnected = MutableStateFlow(true)
     val isConnected: StateFlow<Boolean> get() = _isConnected
-    // CAMBIO: Repository ahora recibe context
+    // update: Repository ahora recibe context
     private val dao = AppDatabase.getDatabase(application).CommentDao()
-    // CAMBIO: Repository ahora recibe context
+    private val readHistoryDao = AppDatabase.getDatabase(application).readHistoryDao()  // updated
+    // update: Repository ahora recibe context
     private val repository = Repository(application.applicationContext, dao)
     private val _newsItem = MutableStateFlow<NewsItem?>(null)
     val newsItem: StateFlow<NewsItem?> = _newsItem.asStateFlow()
@@ -80,24 +82,48 @@ class NewsItemDetailViewModel(
         }
     }
 
+    /**
+     *  NUEVA FUNCION: Register read history
+     * Only registers if the news item hasn't been read before
+     */
+    fun registerReadHistory(newsItem: NewsItem) {
+        viewModelScope.launch {
+            try {
+                // Check if already read
+                val alreadyRead = readHistoryDao.isNewsItemRead(newsItem.news_item_id)
+
+                if (!alreadyRead) {
+                    // Convert NewsItem to ReadHistoryEntity and insert
+                    val historyEntity = newsItem.toReadHistoryEntity()
+                    readHistoryDao.insertReadHistory(historyEntity)
+                    Log.d(TAG, "Read history registered for news item: ${newsItem.news_item_id}")
+                } else {
+                    Log.d(TAG, "News item already in read history: ${newsItem.news_item_id}")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error registering read history: ${e.message}")
+            }
+        }
+    }
+
     fun addComment(userProfileId: Int, comment:String, newsItemId: Int, rating: Double, onSuccess: () -> Unit, onError: (Throwable) -> Unit,onWait: ()-> Unit )
     {
         viewModelScope.launch {
             try {
-             val response = repository.addNewComments(userProfileId,newsItemId, comment = comment, rating = rating, completed = false)
+                val response = repository.addNewComments(userProfileId,newsItemId, comment = comment, rating = rating, completed = false)
 
-             if (response == 0){
-                 withContext(Dispatchers.Main){
-                     onSuccess()
-                     loadNewsItemById(newsItemId)
-                 }
+                if (response == 0){
+                    withContext(Dispatchers.Main){
+                        onSuccess()
+                        loadNewsItemById(newsItemId)
+                    }
 
-             }else if (response == 2) {
-                 Log.w(TAG,"Se activo el encolamiento")
-                 withContext(Dispatchers.Main){
-                     onWait()
-                 }
-             }
+                }else if (response == 2) {
+                    Log.w(TAG,"Se activo el encolamiento")
+                    withContext(Dispatchers.Main){
+                        onWait()
+                    }
+                }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main){
                     onError(e)
@@ -112,8 +138,8 @@ class NewsItemDetailViewModel(
             networkMonitor.isConnected.collect { connected ->
                 _isConnected.value = connected
                 if (connected) {repository.syncPendingComments()
-                repository.clearCache()
-                loadNewsItemById(newsItemid)}
+                    repository.clearCache()
+                    loadNewsItemById(newsItemid)}
 
 
 
@@ -133,14 +159,3 @@ class NewsItemDetailViewModel(
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/app/src/main/java/com/example/sprint_2_kotlin/viewmodel/ReadHistoryViewModel.kt
+++ b/app/src/main/java/com/example/sprint_2_kotlin/viewmodel/ReadHistoryViewModel.kt
@@ -1,0 +1,122 @@
+package com.example.sprint_2_kotlin.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.sprint_2_kotlin.model.data.AppDatabase
+import com.example.sprint_2_kotlin.model.data.ReadHistoryEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for Read History Screen
+ * Manages the user's reading history data
+ */
+class ReadHistoryViewModel(
+    application: Application
+) : AndroidViewModel(application) {
+
+    private val readHistoryDao = AppDatabase.getDatabase(application).readHistoryDao()
+
+    // StateFlow for read history list
+    private val _readHistory = MutableStateFlow<List<ReadHistoryEntity>>(emptyList())
+    val readHistory: StateFlow<List<ReadHistoryEntity>> = _readHistory.asStateFlow()
+
+    // StateFlow for loading state
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    // StateFlow for total count of articles read
+    private val _readCount = MutableStateFlow(0)
+    val readCount: StateFlow<Int> = _readCount.asStateFlow()
+
+    init {
+        loadReadHistory()
+        loadReadCount()
+    }
+
+    /**
+     * Load all read history from database
+     * Observes changes in real-time using Flow
+     */
+    private fun loadReadHistory() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                readHistoryDao.getAllReadHistory().collect { historyList ->
+                    _readHistory.value = historyList
+                    _isLoading.value = false
+                }
+            } catch (e: Exception) {
+                _readHistory.value = emptyList()
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Load total count of articles read
+     * Used for ProfileScreen counter
+     */
+    private fun loadReadCount() {
+        viewModelScope.launch {
+            try {
+                readHistoryDao.getReadCountFlow().collect { count ->
+                    _readCount.value = count
+                }
+            } catch (e: Exception) {
+                _readCount.value = 0
+            }
+        }
+    }
+
+    /**
+     * Refresh the read history
+     * Useful for pull-to-refresh functionality
+     */
+    fun refreshHistory() {
+        loadReadHistory()
+        loadReadCount()
+    }
+
+    /**
+     * Delete a specific history entry
+     */
+    fun deleteHistoryEntry(historyId: Int) {
+        viewModelScope.launch {
+            try {
+                readHistoryDao.deleteHistoryEntry(historyId)
+                // History will auto-update via Flow
+            } catch (e: Exception) {
+                // Handle error if needed
+            }
+        }
+    }
+
+    /**
+     * Clear all read history
+     */
+    fun clearAllHistory() {
+        viewModelScope.launch {
+            try {
+                readHistoryDao.deleteAllHistory()
+                // History will auto-update via Flow
+            } catch (e: Exception) {
+                // Handle error if needed
+            }
+        }
+    }
+
+    /**
+     * Get read count synchronously (for ProfileScreen)
+     */
+    suspend fun getReadCountSync(): Int {
+        return try {
+            readHistoryDao.getReadCount()
+        } catch (e: Exception) {
+            0
+        }
+    }
+}


### PR DESCRIPTION
Now, the user can go to the Profile Screen and check the news that have read so far. Also, in there, the user can select any new from his history in order to read it again, check the gradings and the comments. There's also an option that allows the user to delete the history in case that wants to get rid off it. 

FIX: There was a small bug showing the Category id instead of the Category name when looking at the history, this has been resolved. Now the user see the name of the category